### PR TITLE
add scusd and sceth to Sonic

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -160884,7 +160884,6 @@
           "address": "0x965F527D9159dCe6288a2219DB51fc6Eef120dD1",
           "decimals": 18
         }
-        
       ],
       "timestamp": "2025-02-12T12:28:19.156Z"
     },
@@ -163098,7 +163097,6 @@
           "address": "0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3",
           "decimals": 18
         }
-        
       ],
       "timestamp": "2025-02-12T12:28:19.156Z"
     },
@@ -175097,8 +175095,6 @@
           "address": "0xCE7de646e7208a4Ef112cb6ed5038FA6cC6b12e3",
           "decimals": 6
         }
-        
-
       ],
       "timestamp": "2025-02-12T12:28:19.156Z"
     },
@@ -182470,8 +182466,37 @@
         }
       ],
       "timestamp": "2025-02-12T12:28:19.156Z"
+    },
+    {
+      "name": "Rings Protocol Sonic USD",
+      "symbol": "scUSD",
+      "sources": [
+        {
+          "type": "coingecko",
+          "data": "rings-scusd"
+        }
+      ],
+      "contracts": [
+        {
+          "chain": "sonic",
+          "address": "0xd3DCe716f3eF535C5Ff8d041c1A41C3bd89b97aE",
+          "decimals": 6
+        }
+      ],
+      "timestamp": "2025-02-13T16:51:00.000Z"
+    },
+    {
+      "name": "Rings Protocol Sonic ETH",
+      "symbol": "scETH",
+      "sources": [],
+      "contracts": [
+        {
+          "chain": "sonic",
+          "address": "0x3bcE5CB273F0F148010BbEa2470e7b5df84C7812",
+          "decimals": 18
+        }
+      ],
+      "timestamp": "2025-02-13T16:51:00.000Z"
     }
-
-    
   ]
 }


### PR DESCRIPTION
Hi,
I just added scUSD and scETH tokens, on Sonic, from Rings Protocol.
scUSD in particular is an important token for the ecosystem as it is the de facto yield bearing stablecoin on Sonic.
Alas, I could not find sources for scETH.
Cheers,
Cocco